### PR TITLE
feat: 支持“今日市场新闻”后端接口与可热加载搜索配置

### DIFF
--- a/agentApi/src/main/proto/agentService.proto
+++ b/agentApi/src/main/proto/agentService.proto
@@ -331,6 +331,33 @@ message ListAgentMessagesResponse {
   bool has_more = 3;
 }
 
+message GetTodayMarketNewsRequest {
+  string user_id = 1;
+  int32 limit = 2;
+  string provider = 3;
+  string market = 4;
+  string language = 5;
+  string start_published_at = 6;
+  string end_published_at = 7;
+}
+
+message MarketNewsItemMessage {
+  string id = 1;
+  string timestamp = 2;
+  string title = 3;
+  string source = 4;
+  string category = 5;
+  string url = 6;
+  string summary = 7;
+  string provider = 8;
+}
+
+message GetTodayMarketNewsResponse {
+  repeated MarketNewsItemMessage data = 1;
+  string updated_at = 2;
+  string provider = 3;
+}
+
 service AgentDubboService {
   rpc CreateRun(CreateAgentRunRequest) returns (AgentRunMessage);
   rpc GetRun(GetAgentRunRequest) returns (AgentRunMessage);
@@ -354,4 +381,5 @@ service AgentDubboService {
   rpc ExportRun(ExportAgentRunRequest) returns (ExportAgentRunResponse);
   rpc SendMessage(SendAgentMessageRequest) returns (SendAgentMessageResponse);
   rpc ListMessages(ListAgentMessagesRequest) returns (ListAgentMessagesResponse);
+  rpc GetTodayMarketNews(GetTodayMarketNewsRequest) returns (GetTodayMarketNewsResponse);
 }

--- a/agentService/config/prompts/search/market_news_user_template.txt
+++ b/agentService/config/prompts/search/market_news_user_template.txt
@@ -1,0 +1,5 @@
+请你检索{{market}}在{{startPublishedAt}}到{{endPublishedAt}}之间发布的最新市场新闻，返回{{limit}}条结果。
+要求：
+1. 检索时优先使用{{language}}相关来源；
+2. 每条结果应包含发布时间、标题、来源和URL；
+3. 仅返回真实可追溯来源，不要编造链接。

--- a/agentService/config/search-llm.local.example.json
+++ b/agentService/config/search-llm.local.example.json
@@ -1,0 +1,38 @@
+{
+  "enabled": true,
+  "defaultProvider": "exa",
+  "defaultLimit": 10,
+  "defaultLanguage": "zh",
+  "connectTimeoutMillis": 10000,
+  "requestTimeoutMillis": 30000,
+  "prompts": {
+    "marketNewsUserTemplate": "file:prompts/search/market_news_user_template.txt"
+  },
+  "providers": {
+    "exa": {
+      "type": "exa-search",
+      "endpoint": "https://api.exa.ai/search",
+      "apiKey": "${EXA_API_KEY}",
+      "searchMode": "auto",
+      "category": "news",
+      "maxResults": 10
+    },
+    "perplexity": {
+      "type": "perplexity-search",
+      "endpoint": "https://api.perplexity.ai/search",
+      "apiKey": "${PERPLEXITY_API_KEY}",
+      "searchRecencyFilter": "day",
+      "country": "CN",
+      "maxResults": 10
+    },
+    "perplexity_sonar": {
+      "type": "perplexity-sonar",
+      "endpoint": "https://api.perplexity.ai/chat/completions",
+      "apiKey": "${PERPLEXITY_API_KEY}",
+      "model": "sonar-pro",
+      "searchMode": "web",
+      "searchRecencyFilter": "day",
+      "maxResults": 10
+    }
+  }
+}

--- a/agentService/src/main/java/world/willfrog/agent/config/SearchLlmProperties.java
+++ b/agentService/src/main/java/world/willfrog/agent/config/SearchLlmProperties.java
@@ -1,0 +1,37 @@
+package world.willfrog.agent.config;
+
+import lombok.Data;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Data
+public class SearchLlmProperties {
+
+    private boolean enabled = true;
+    private String defaultProvider = "exa";
+    private Integer defaultLimit = 10;
+    private String defaultLanguage = "zh";
+    private Integer connectTimeoutMillis = 10000;
+    private Integer requestTimeoutMillis = 30000;
+    private Prompts prompts = new Prompts();
+    private Map<String, Provider> providers = new LinkedHashMap<>();
+
+    @Data
+    public static class Prompts {
+        private String marketNewsUserTemplate = "请搜索{{market}}今日市场新闻，返回{{limit}}条，检索结果使用{{language}}，请优先选择发布时间在{{startPublishedAt}}至{{endPublishedAt}}之间的新闻。";
+    }
+
+    @Data
+    public static class Provider {
+        private String type;
+        private String endpoint;
+        private String apiKey;
+        private String model;
+        private String searchMode;
+        private String searchRecencyFilter;
+        private String category;
+        private String country;
+        private Integer maxResults;
+    }
+}

--- a/agentService/src/main/java/world/willfrog/agent/model/MarketNewsItem.java
+++ b/agentService/src/main/java/world/willfrog/agent/model/MarketNewsItem.java
@@ -1,0 +1,13 @@
+package world.willfrog.agent.model;
+
+public record MarketNewsItem(
+        String id,
+        String timestamp,
+        String title,
+        String source,
+        String category,
+        String url,
+        String summary,
+        String provider
+) {
+}

--- a/agentService/src/main/java/world/willfrog/agent/service/MarketNewsService.java
+++ b/agentService/src/main/java/world/willfrog/agent/service/MarketNewsService.java
@@ -1,0 +1,208 @@
+package world.willfrog.agent.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import world.willfrog.agent.config.SearchLlmProperties;
+import world.willfrog.agent.model.MarketNewsItem;
+
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.OffsetDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MarketNewsService {
+
+    private final SearchLlmLocalConfigLoader configLoader;
+    private final ObjectMapper objectMapper;
+    private final HttpClient httpClient = HttpClient.newBuilder().connectTimeout(Duration.ofSeconds(10)).build();
+
+    public NewsResult getTodayNews(String provider,
+                                   String market,
+                                   String language,
+                                   int limit,
+                                   String startPublishedAt,
+                                   String endPublishedAt) {
+        SearchLlmProperties cfg = configLoader.current().orElseThrow(() -> new IllegalStateException("search config not loaded"));
+        String providerKey = provider == null || provider.isBlank() ? cfg.getDefaultProvider() : provider.trim();
+        SearchLlmProperties.Provider providerConfig = cfg.getProviders().get(providerKey);
+        if (providerConfig == null) {
+            throw new IllegalArgumentException("unsupported provider: " + providerKey);
+        }
+        int finalLimit = limit > 0 ? limit : (cfg.getDefaultLimit() == null ? 10 : cfg.getDefaultLimit());
+        String finalLanguage = language == null || language.isBlank() ? cfg.getDefaultLanguage() : language;
+        String finalStart = startPublishedAt == null || startPublishedAt.isBlank() ? OffsetDateTime.now().withHour(0).withMinute(0).withSecond(0).withNano(0).toString() : startPublishedAt;
+        String finalEnd = endPublishedAt == null || endPublishedAt.isBlank() ? OffsetDateTime.now().toString() : endPublishedAt;
+
+        String type = providerConfig.getType() == null ? "exa-search" : providerConfig.getType();
+        List<MarketNewsItem> items;
+        if ("exa-search".equalsIgnoreCase(type)) {
+            items = callExa(providerKey, providerConfig, finalLimit, market, finalLanguage, finalStart, finalEnd);
+        } else if ("perplexity-search".equalsIgnoreCase(type)) {
+            items = callPerplexitySearch(providerKey, providerConfig, finalLimit, market, finalLanguage);
+        } else if ("perplexity-sonar".equalsIgnoreCase(type)) {
+            items = callPerplexitySonar(providerKey, providerConfig, finalLimit, market, finalLanguage, finalStart, finalEnd, cfg);
+        } else {
+            throw new IllegalArgumentException("unsupported provider type: " + type);
+        }
+        items.sort(Comparator.comparing(MarketNewsItem::timestamp, Comparator.nullsLast(Comparator.reverseOrder())));
+        return new NewsResult(items.stream().limit(finalLimit).toList(), OffsetDateTime.now().toString(), providerKey);
+    }
+
+    private List<MarketNewsItem> callExa(String provider,
+                                         SearchLlmProperties.Provider config,
+                                         int limit,
+                                         String market,
+                                         String language,
+                                         String start,
+                                         String end) {
+        try {
+            Map<String, Object> body = Map.of(
+                    "query", queryText(market, language),
+                    "type", config.getSearchMode() == null ? "auto" : config.getSearchMode(),
+                    "category", config.getCategory() == null ? "news" : config.getCategory(),
+                    "numResults", Math.min(Math.max(limit, 1), 100),
+                    "startPublishedDate", start,
+                    "endPublishedDate", end,
+                    "contents", Map.of("summary", true)
+            );
+            JsonNode root = postJson(config.getEndpoint(), Map.of("x-api-key", config.getApiKey()), body);
+            List<MarketNewsItem> out = new ArrayList<>();
+            for (JsonNode item : root.path("results")) {
+                out.add(new MarketNewsItem(
+                        item.path("id").asText(item.path("url").asText()),
+                        item.path("publishedDate").asText(""),
+                        item.path("title").asText(""),
+                        item.path("author").asText(""),
+                        "market",
+                        item.path("url").asText(""),
+                        item.path("summary").asText(""),
+                        provider
+                ));
+            }
+            return out;
+        } catch (Exception e) {
+            throw new RuntimeException("exa search failed", e);
+        }
+    }
+
+    private List<MarketNewsItem> callPerplexitySearch(String provider,
+                                                       SearchLlmProperties.Provider config,
+                                                       int limit,
+                                                       String market,
+                                                       String language) {
+        try {
+            Map<String, Object> body = Map.of(
+                    "query", queryText(market, language),
+                    "max_results", Math.min(Math.max(limit, 1), 20),
+                    "search_recency_filter", config.getSearchRecencyFilter() == null ? "day" : config.getSearchRecencyFilter(),
+                    "search_language_filter", List.of(language)
+            );
+            JsonNode root = postJson(config.getEndpoint(), Map.of("Authorization", "Bearer " + config.getApiKey()), body);
+            List<MarketNewsItem> out = new ArrayList<>();
+            for (JsonNode item : root.path("results")) {
+                out.add(new MarketNewsItem(
+                        item.path("url").asText(""),
+                        item.path("last_updated").asText(item.path("date").asText("")),
+                        item.path("title").asText(""),
+                        "",
+                        "market",
+                        item.path("url").asText(""),
+                        item.path("snippet").asText(""),
+                        provider
+                ));
+            }
+            return out;
+        } catch (Exception e) {
+            throw new RuntimeException("perplexity search failed", e);
+        }
+    }
+
+    private List<MarketNewsItem> callPerplexitySonar(String provider,
+                                                      SearchLlmProperties.Provider config,
+                                                      int limit,
+                                                      String market,
+                                                      String language,
+                                                      String start,
+                                                      String end,
+                                                      SearchLlmProperties properties) {
+        try {
+            String prompt = buildPrompt(properties.getPrompts().getMarketNewsUserTemplate(), market, language, limit, start, end);
+            Map<String, Object> body = Map.of(
+                    "model", config.getModel() == null ? "sonar-pro" : config.getModel(),
+                    "messages", List.of(Map.of("role", "user", "content", prompt)),
+                    "search_recency_filter", config.getSearchRecencyFilter() == null ? "day" : config.getSearchRecencyFilter(),
+                    "search_mode", config.getSearchMode() == null ? "web" : config.getSearchMode()
+            );
+            JsonNode root = postJson(config.getEndpoint(), Map.of("Authorization", "Bearer " + config.getApiKey()), body);
+            String content = root.path("choices").path(0).path("message").path("content").asText("");
+            List<MarketNewsItem> out = new ArrayList<>();
+            int idx = 1;
+            for (JsonNode citation : root.path("citations")) {
+                out.add(new MarketNewsItem(
+                        "citation_" + idx,
+                        "",
+                        citation.path("title").asText(""),
+                        citation.path("title").asText(""),
+                        "market",
+                        citation.path("url").asText(""),
+                        content,
+                        provider
+                ));
+                idx++;
+            }
+            return out;
+        } catch (Exception e) {
+            throw new RuntimeException("perplexity sonar failed", e);
+        }
+    }
+
+    private String buildPrompt(String template, String market, String language, int limit, String start, String end) {
+        String raw = template == null || template.isBlank()
+                ? "请整理今日市场新闻"
+                : template;
+        return raw.replace("{{market}}", market == null || market.isBlank() ? "全球市场" : market)
+                .replace("{{language}}", language)
+                .replace("{{limit}}", String.valueOf(limit))
+                .replace("{{startPublishedAt}}", start)
+                .replace("{{endPublishedAt}}", end);
+    }
+
+    private String queryText(String market, String language) {
+        String marketPart = market == null || market.isBlank() ? "全球市场" : market;
+        return marketPart + " 今日财经新闻 " + language;
+    }
+
+    private JsonNode postJson(String endpoint, Map<String, String> headers, Map<String, Object> body) throws Exception {
+        String json = objectMapper.writeValueAsString(body);
+        HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(endpoint))
+                .header("Content-Type", "application/json")
+                .timeout(Duration.ofSeconds(30))
+                .POST(HttpRequest.BodyPublishers.ofString(json));
+        for (Map.Entry<String, String> entry : headers.entrySet()) {
+            if (entry.getValue() != null && !entry.getValue().isBlank()) {
+                builder.header(entry.getKey(), entry.getValue());
+            }
+        }
+        HttpResponse<String> response = httpClient.send(builder.build(), HttpResponse.BodyHandlers.ofString());
+        if (response.statusCode() >= 400) {
+            log.error("search provider request failed: status={} body={}", response.statusCode(), response.body());
+            throw new IllegalStateException("search provider request failed: " + response.statusCode());
+        }
+        return objectMapper.readTree(response.body());
+    }
+
+    public record NewsResult(List<MarketNewsItem> items, String updatedAt, String provider) {
+    }
+}

--- a/agentService/src/main/java/world/willfrog/agent/service/SearchLlmLocalConfigLoader.java
+++ b/agentService/src/main/java/world/willfrog/agent/service/SearchLlmLocalConfigLoader.java
@@ -1,0 +1,153 @@
+package world.willfrog.agent.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import world.willfrog.agent.config.SearchLlmProperties;
+
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class SearchLlmLocalConfigLoader {
+
+    private static final String FILE_PREFIX = "file:";
+    private static final String FILE_PREFIX_ALT = "file://";
+    private static final String FILE_PREFIX_AT = "@file:";
+
+    private final ObjectMapper objectMapper;
+
+    @Value("${agent.search.config-file:}")
+    private String configFile;
+
+    private volatile SearchLlmProperties localConfig;
+    private volatile String loadedConfigPath = "";
+    private volatile long loadedConfigLastModified = Long.MIN_VALUE;
+    private volatile Map<String, Long> loadedPromptFileModifiedTimes = new LinkedHashMap<>();
+    private final Object reloadLock = new Object();
+
+    @PostConstruct
+    public void load() {
+        reloadIfNeeded(true);
+    }
+
+    @Scheduled(fixedDelayString = "${agent.search.config-refresh-interval-ms:10000}")
+    public void refresh() {
+        reloadIfNeeded(false);
+    }
+
+    public Optional<SearchLlmProperties> current() {
+        return Optional.ofNullable(localConfig);
+    }
+
+    private void reloadIfNeeded(boolean force) {
+        String file = configFile == null ? "" : configFile.trim();
+        if (file.isEmpty()) {
+            clearIfPresent();
+            return;
+        }
+        Path path = Paths.get(file).toAbsolutePath().normalize();
+        synchronized (reloadLock) {
+            if (!Files.exists(path)) {
+                clearIfPresent();
+                return;
+            }
+            try {
+                long currentModified = Files.getLastModifiedTime(path).toMillis();
+                boolean unchanged = path.toString().equals(loadedConfigPath) && currentModified == loadedConfigLastModified;
+                if (!force && unchanged && !promptFilesChanged()) {
+                    return;
+                }
+                SearchLlmProperties parsed = objectMapper.readValue(Files.newInputStream(path), SearchLlmProperties.class);
+                Map<String, Long> promptFileTimes = resolvePromptFiles(parsed, path.getParent());
+                this.localConfig = parsed;
+                this.loadedConfigPath = path.toString();
+                this.loadedConfigLastModified = currentModified;
+                this.loadedPromptFileModifiedTimes = promptFileTimes;
+                log.info("Loaded search llm local config: {}", path);
+            } catch (Exception e) {
+                log.error("Failed to load search llm local config: {}", path, e);
+            }
+        }
+    }
+
+    private void clearIfPresent() {
+        synchronized (reloadLock) {
+            this.localConfig = null;
+            this.loadedConfigPath = "";
+            this.loadedConfigLastModified = Long.MIN_VALUE;
+            this.loadedPromptFileModifiedTimes = new LinkedHashMap<>();
+        }
+    }
+
+    private Map<String, Long> resolvePromptFiles(SearchLlmProperties config, Path baseDir) {
+        Map<String, Long> fileTimes = new LinkedHashMap<>();
+        if (config == null || config.getPrompts() == null) {
+            return fileTimes;
+        }
+        config.getPrompts().setMarketNewsUserTemplate(resolvePromptText(config.getPrompts().getMarketNewsUserTemplate(), baseDir, fileTimes));
+        return fileTimes;
+    }
+
+    private String resolvePromptText(String value, Path baseDir, Map<String, Long> fileTimes) {
+        if (value == null || value.isBlank()) {
+            return value;
+        }
+        String filePathRef = stripFilePrefix(value.trim());
+        if (filePathRef == null) {
+            return value;
+        }
+        try {
+            Path filePath = Paths.get(filePathRef);
+            if (!filePath.isAbsolute()) {
+                filePath = baseDir.resolve(filePathRef).toAbsolutePath().normalize();
+            }
+            fileTimes.put(filePath.toString(), Files.getLastModifiedTime(filePath).toMillis());
+            return Files.readString(filePath, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            log.error("Failed to read search prompt file: {}", filePathRef, e);
+            return "";
+        }
+    }
+
+    private boolean promptFilesChanged() {
+        for (Map.Entry<String, Long> entry : loadedPromptFileModifiedTimes.entrySet()) {
+            try {
+                Path path = Paths.get(entry.getKey());
+                if (!Files.exists(path)) {
+                    return true;
+                }
+                if (Files.getLastModifiedTime(path).toMillis() != entry.getValue()) {
+                    return true;
+                }
+            } catch (Exception e) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String stripFilePrefix(String raw) {
+        if (raw.startsWith(FILE_PREFIX_ALT)) {
+            return raw.substring(FILE_PREFIX_ALT.length()).trim();
+        }
+        if (raw.startsWith(FILE_PREFIX)) {
+            return raw.substring(FILE_PREFIX.length()).trim();
+        }
+        if (raw.startsWith(FILE_PREFIX_AT)) {
+            return raw.substring(FILE_PREFIX_AT.length()).trim();
+        }
+        return null;
+    }
+}

--- a/agentService/src/main/resources/application.yml
+++ b/agentService/src/main/resources/application.yml
@@ -29,6 +29,10 @@ dubbo:
     check: false
 
 agent:
+  search:
+    # 本地搜索配置（可选），支持热加载
+    config-file: ${AF_AGENT_SEARCH_CONFIG_FILE:}
+    config-refresh-interval-ms: ${AF_AGENT_SEARCH_CONFIG_REFRESH_INTERVAL_MS:10000}
   run:
     interrupted-ttl-days: ${AF_AGENT_RUN_INTERRUPTED_TTL_DAYS:7}
     checkpoint-version: ${AF_AGENT_RUN_CHECKPOINT_VERSION:v2}

--- a/frontend/src/main/java/world/willfrog/alphafrogmicro/frontend/controller/agent/MarketNewsController.java
+++ b/frontend/src/main/java/world/willfrog/alphafrogmicro/frontend/controller/agent/MarketNewsController.java
@@ -1,0 +1,96 @@
+package world.willfrog.alphafrogmicro.frontend.controller.agent;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.dubbo.config.annotation.DubboReference;
+import org.apache.dubbo.rpc.RpcException;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+import world.willfrog.alphafrogmicro.agent.idl.AgentDubboService;
+import world.willfrog.alphafrogmicro.agent.idl.GetTodayMarketNewsRequest;
+import world.willfrog.alphafrogmicro.common.dto.ResponseCode;
+import world.willfrog.alphafrogmicro.common.dto.ResponseWrapper;
+import world.willfrog.alphafrogmicro.common.pojo.user.User;
+import world.willfrog.alphafrogmicro.frontend.model.market.MarketNewsItemResponse;
+import world.willfrog.alphafrogmicro.frontend.model.market.TodayMarketNewsResponse;
+import world.willfrog.alphafrogmicro.frontend.service.AuthService;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/v1/market/news")
+@RequiredArgsConstructor
+@Slf4j
+public class MarketNewsController {
+
+    @DubboReference
+    private AgentDubboService agentDubboService;
+
+    private final AuthService authService;
+
+    @GetMapping("/today")
+    public ResponseWrapper<TodayMarketNewsResponse> today(Authentication authentication,
+                                                          @RequestParam(value = "limit", required = false) Integer limit,
+                                                          @RequestParam(value = "provider", required = false) String provider,
+                                                          @RequestParam(value = "market", required = false) String market,
+                                                          @RequestParam(value = "language", required = false) String language,
+                                                          @RequestParam(value = "startPublishedAt", required = false) String startPublishedAt,
+                                                          @RequestParam(value = "endPublishedAt", required = false) String endPublishedAt) {
+        String userId = resolveUserId(authentication);
+        if (userId == null) {
+            return ResponseWrapper.error(ResponseCode.UNAUTHORIZED, "未登录或用户不存在");
+        }
+        try {
+            var rpcResp = agentDubboService.getTodayMarketNews(
+                    GetTodayMarketNewsRequest.newBuilder()
+                            .setUserId(userId)
+                            .setLimit(limit == null ? 0 : limit)
+                            .setProvider(nvl(provider))
+                            .setMarket(nvl(market))
+                            .setLanguage(nvl(language))
+                            .setStartPublishedAt(nvl(startPublishedAt))
+                            .setEndPublishedAt(nvl(endPublishedAt))
+                            .build()
+            );
+            List<MarketNewsItemResponse> items = new ArrayList<>();
+            for (var item : rpcResp.getDataList()) {
+                items.add(new MarketNewsItemResponse(
+                        item.getId(),
+                        item.getTimestamp(),
+                        item.getTitle(),
+                        item.getSource(),
+                        item.getCategory(),
+                        item.getUrl(),
+                        item.getSummary(),
+                        item.getProvider()
+                ));
+            }
+            return ResponseWrapper.success(new TodayMarketNewsResponse(items, rpcResp.getUpdatedAt(), rpcResp.getProvider()));
+        } catch (RpcException e) {
+            log.error("查询今日市场新闻失败: {}", e.getMessage());
+            return ResponseWrapper.error(ResponseCode.EXTERNAL_SERVICE_ERROR, "查询今日市场新闻失败");
+        } catch (Exception e) {
+            log.error("查询今日市场新闻失败", e);
+            return ResponseWrapper.error(ResponseCode.SYSTEM_ERROR, "查询今日市场新闻失败");
+        }
+    }
+
+    private String resolveUserId(Authentication authentication) {
+        if (authentication == null || !authentication.isAuthenticated()) {
+            return null;
+        }
+        User user = authService.getUserByUsername(authentication.getName());
+        if (user == null || user.getUserId() == null) {
+            return null;
+        }
+        return String.valueOf(user.getUserId());
+    }
+
+    private String nvl(String text) {
+        return text == null ? "" : text;
+    }
+}

--- a/frontend/src/main/java/world/willfrog/alphafrogmicro/frontend/model/market/MarketNewsItemResponse.java
+++ b/frontend/src/main/java/world/willfrog/alphafrogmicro/frontend/model/market/MarketNewsItemResponse.java
@@ -1,0 +1,13 @@
+package world.willfrog.alphafrogmicro.frontend.model.market;
+
+public record MarketNewsItemResponse(
+        String id,
+        String timestamp,
+        String title,
+        String source,
+        String category,
+        String url,
+        String summary,
+        String provider
+) {
+}

--- a/frontend/src/main/java/world/willfrog/alphafrogmicro/frontend/model/market/TodayMarketNewsResponse.java
+++ b/frontend/src/main/java/world/willfrog/alphafrogmicro/frontend/model/market/TodayMarketNewsResponse.java
@@ -1,0 +1,10 @@
+package world.willfrog.alphafrogmicro.frontend.model.market;
+
+import java.util.List;
+
+public record TodayMarketNewsResponse(
+        List<MarketNewsItemResponse> data,
+        String updatedAt,
+        String provider
+) {
+}


### PR DESCRIPTION
### Motivation
- 为个人中心页面 `/app/profile` 提供真实的“今日市场新闻”数据接口，替换前端当前的静态演示数据并支持多源检索与可扩展的 provider 配置。 
- 支持使用第三方 AI 搜索（如 Exa / Perplexity / Perplexity Sonar）获取新闻并在后端进行统一规范化，避免前端与 provider 强耦合。 
- 设计可热加载的本地配置以便部署端灵活切换 provider、prompt 与限流参数，避免将来源与 prompt 硬编码到代码中。 

### Description
- 在 agent API 的 protobuf 中新增 `GetTodayMarketNewsRequest` / `GetTodayMarketNewsResponse` 与 `MarketNewsItemMessage`，并在 `AgentDubboService` 中增加 `GetTodayMarketNews` RPC。 
- 在 `agentService` 中新增 `MarketNewsService`，实现对 `exa-search`、`perplexity-search` 与 `perplexity-sonar` 三类 provider 的调用适配与结果归一化，返回统一的 `id/timestamp/title/source/category/url/summary/provider` 结构。 
- 新增本地配置模型 `SearchLlmProperties` 与 `SearchLlmLocalConfigLoader`，通过 `agent.search.config-file` 支持 `search-llm` JSON 配置文件和 prompt 的热加载（示例文件 `agentService/config/search-llm.local.example.json` 与 prompt 模板已加入仓库作为 example）。 
- 在 `AgentDubboServiceImpl` 中注入并实现 `getTodayMarketNews` 方法以调用 `MarketNewsService`，并在 `application.yml` 中添加 `agent.search` 配置项用于开启/定位本地搜索配置。 
- 在 frontend 新增 REST 接口 `GET /api/v1/market/news/today`（`MarketNewsController`）以及响应模型 `TodayMarketNewsResponse` / `MarketNewsItemResponse`，将查询参数（`limit/provider/market/language/startPublishedAt/endPublishedAt`）透传至 agent 服务并返回给前端。 
- 新增示例 prompt 文件 `agentService/config/prompts/search/market_news_user_template.txt` 以及 `search-llm.local.example.json` 用于部署侧自定义 provider、API key 与 prompt 模板。 

### Testing
- 运行编译验证：执行 `mvn -pl agentService,frontend -am -DskipTests compile`，构建结果为 `BUILD SUCCESS`，证明新增代码通过了编译和 protobuf 生成流程。 
- 未引入自动化单元测试改动，故未运行单元测试套件；建议在后续迭代中为 `MarketNewsService` 的 provider 适配逻辑补充单元测试与集成测试。

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b5ff68e7c832eb6c19d65f606b349)